### PR TITLE
Updated gradient descent to use line search

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Currently it has the following features
   of iterations. If multiple stopping conditions are provided, it will be treated as `OR` (if either
   stopping condition is fulfilled, the optimizer stops training)
 
-## Note - this library is not yet production ready
+**Note - this library is not yet production ready**
 
 ## Usage
 
@@ -51,8 +51,10 @@ the available options
 * `:learning-rate` (or alpha) - default value is 1.0
 * `:regularization-rate` (or lambda) - default value is 0.0
 * `:activation-fn` - default value is sigmoid function
-* `:stopping-conditions` - default value is maximum iterations of 100
-* `:optimizer` - default value is gradient descent
+* `:optimizer` - default value is gradient descent with the following settings
+    * learning rate of 8
+    * learning rate update rate of 0.5
+    * single stopping conditions of 100 iterations
 
 Example of options
 
@@ -63,6 +65,5 @@ Example of options
 
 (def options {:activation-fn sigmoid
               :stopping-conditions [(max-iterations 100)]
-              :optimizer (gradient-descent (:learning-rate merged-options)
-                                           (:stopping-conditions merged-options))})
+              :optimizer (gradient-descent 8 0.5 [(max-iterations 100)]})
 ```

--- a/src/neuralnetworks/core.clj
+++ b/src/neuralnetworks/core.clj
@@ -68,19 +68,28 @@
   "Creates new instance of neural networks.
 
    Options will be a hash map of
-   {:learning-rate value
-    :regularization-rate value
+
+   ```
+   {:regularization-rate value
     :activation-fn function
-    :stopping-conditions [functions]
     :optimizer optimizer}
+   ```
 
    Thetas would be the vector of initial weights matrices between each layer. To create a single
    hidden layer, Thetas would be a vector of two weight matrices.
 
-   Stopping conditions is a vector of stopping condition functions. By default training will be
-   finished once it reaches 100 iterations (max-iteration stopping condition). If multiple stopping
-   conditions are provided, it will be treated as *OR* meaning as long as one of the condition is
-   satisfied, training will be stopped
+   If optimizer is not specified, by default it will use gradient descent optimizer with the
+   following settings:
+
+   * initial learning rate of 8
+   * learning rate update of 0.5
+   * single stopping condition of 100 iterations
+
+   Stopping conditions is a vector of stopping condition functions used by the optimizer which in
+   turn used by neural networks training function.
+
+   If multiple stopping conditions are provided, it will be treated as *OR* meaning as long as one
+   of the condition is satisfied, training will be stopped (i.e. optimizer is finished)
 
    Returns a hashmap
    ```
@@ -88,10 +97,8 @@
      :input input-matrix
      :output output-matrix
      :regularization-rate value (default is 0)
-     :learning-rate value (default is 1)
-     :stopping-conditions [function-1, function-2, ...] (default is 100 iterations)
      :activation-fn function (default is sigmoid)
-     :optimizer optimizer function (default is gradient-descent)
+     :optimizer optimizer function (default is gradient-descent with the default options)
      :states {
                :thetas [theta-matrix-1, theta-matrix-2, ...]
                :iteration (atom 0)
@@ -103,18 +110,12 @@
    (new-instance input thetas output {}))
   ([input thetas output options]
    (let [merged-options (merge {:regularization-rate 0
-                                :learning-rate       1
                                 :activation-fn       sigmoid
-                                :stopping-conditions [(max-iterations 100)]}
-                               options)
-         merged-options (merge {:optimizer (gradient-descent (:learning-rate merged-options)
-                                                             (:stopping-conditions merged-options))}
-                               merged-options)]
+                                :optimizer (gradient-descent 8 0.5 [(max-iterations 100)])}
+                               options)]
      {:input               input
       :output              output
       :regularization-rate (:regularization-rate merged-options)
-      :learning-rate       (:learning-rate merged-options)
-      :stopping-conditions (:stopping-conditions merged-options)
       :activation-fn       (:activation-fn merged-options)
       :optimizer           (:optimizer merged-options)
       :states              {:thetas    (atom thetas)

--- a/src/neuralnetworks/optimizer/gradient_descent.clj
+++ b/src/neuralnetworks/optimizer/gradient_descent.clj
@@ -8,7 +8,35 @@
   [thetas theta-gradients alpha]
   (mapv #(m/sub %1 (m/mul %2 alpha)) thetas theta-gradients))
 
-(defrecord GradientDescent [learning-rate stopping-conditions]
+(defn line-search
+  "Uses backtrack line search algorithm to find the best learning-rate (alpha) value.
+
+   Backtrack will stop if either of the following conditions are met:
+
+   * Cost of new theta (updated theta - i.e. theta is updated with alpha and gradients) is less or
+     equals to cost of the original theta minus gradient length squared with alpha
+   * Approximately alpha reaches almost zero (1e-10)
+   * Approximately all gradients almost zero (1e-10)
+
+   Reference: [Gradient Descent Revisited](https://www.cs.cmu.edu/~ggordon/10725-F12/slides/05-gd-revisited.pdf)"
+  [cost-fn init-alpha beta thetas theta-gradients]
+  ; FIXME if beta is 1, ignore line search
+  (let [zero-matrix (m/zero-vector (m/length theta-gradients))]
+    (loop [alpha init-alpha]
+      (let [theta-with-gradient (m/sub thetas (m/mul alpha theta-gradients))
+            cost-theta-with-alpha (:cost (cost-fn theta-with-gradient))
+            cost-theta (:cost (cost-fn thetas))
+            gradient-length-squard-with-alpha (-> theta-gradients
+                                                  m/length-squared
+                                                  (* alpha 0.5))]
+
+        (if (or (<= cost-theta-with-alpha (- cost-theta gradient-length-squard-with-alpha))
+                (<= alpha 1e-10)
+                (m/equals theta-gradients zero-matrix 1e-10))
+          alpha
+          (recur (* beta alpha)))))))
+
+(defrecord GradientDescent [initial-learning-rate learning-rate-update-rate stopping-conditions]
   Optimizer
   (optimize [this cost-fn thetas]
     (loop [iteration 0
@@ -21,16 +49,28 @@
           (throw (ex-info "Gradients is not returned by the cost function " {:cost cost})))
         (if (some #(% optimizer) stopping-conditions)
           (select-keys optimizer [:iteration :error :thetas])
-          (recur (inc iteration)
-                 (update-thetas thetas (m/as-vector (:gradients cost)) learning-rate)))))))
+          (let [alpha (line-search cost-fn
+                                   initial-learning-rate
+                                   learning-rate-update-rate
+                                   thetas
+                                   (m/as-vector (:gradients cost)))]
+            (recur (inc iteration)
+                   (update-thetas thetas (m/as-vector (:gradients cost))
+                                  alpha))))))))
 
 (defn gradient-descent
-  "Creates new instance of gradient descent optimizer.
+  "Creates new instance of gradient descent optimizer. It uses Backtracking Line Search to find the
+   good value of learning-rate (alpha) to allows it converge faster
+
+   To disable backtracking line search, simply set the learning-rate-update-rate to 1.0
+
+   Learning-rate-update-rate must be between (0, 1]
 
    Cost function must returns both `gradients` and `cost` value
    ```
    {:cost 1.5142
     :gradients [1.2 -0.5]}
    ```"
-  [learning-rate stopping-conditions]
-  (->GradientDescent learning-rate stopping-conditions))
+  [initial-learning-rate learning-rate-update-rate stopping-conditions]
+  {:pre [(> learning-rate-update-rate 0) (<= learning-rate-update-rate 1)]}
+  (->GradientDescent initial-learning-rate learning-rate-update-rate stopping-conditions))

--- a/test/neuralnetworks/core_test.clj
+++ b/test/neuralnetworks/core_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer :all]
             [neuralnetworks.core :as nn]
             [neuralnetworks.optimizer.stopping-conditions :refer [max-iterations]]
+            [neuralnetworks.optimizer.gradient-descent :as gd]
             [clojure.core.matrix :as m]))
 
 (deftest test-train-and
@@ -16,12 +17,7 @@
         theta-hidden-layer-output (m/array [[0.453169 -1.037344 -0.837474 0.985438]])
         thetas [theta-input-hidden-layer theta-hidden-layer-output]
         output (m/array [[0] [0] [0] [1]])
-        instance (nn/new-instance input
-                                  thetas
-                                  output
-                                  {:regularization-rate 0
-                                   :learning-rate       2
-                                   :stopping-conditions [(max-iterations 200)]})]
+        instance (nn/new-instance input thetas output {})]
     (nn/train! instance)
     (is (m/equals output (nn/predict instance input) 0.1))))
 
@@ -37,12 +33,7 @@
         theta-hidden-layer-output (m/array [[0.453169 -1.037344 -0.837474 0.985438]])
         thetas [theta-input-hidden-layer theta-hidden-layer-output]
         output (m/array [[0] [1] [1] [0]])
-        instance (nn/new-instance input
-                                  thetas
-                                  output
-                                  {:regularization-rate 0
-                                   :learning-rate       2
-                                   :stopping-conditions [(max-iterations 200)]})]
+        instance (nn/new-instance input thetas output {})]
     (nn/train! instance)
     (is (m/equals output (nn/predict instance input) 0.1))))
 

--- a/test/neuralnetworks/optimizer/gradient_descent_test.clj
+++ b/test/neuralnetworks/optimizer/gradient_descent_test.clj
@@ -3,7 +3,8 @@
             [clojure.core.matrix :as m]
             [neuralnetworks.optimizer :as optimizer]
             [neuralnetworks.optimizer.gradient-descent :as gd]
-            [neuralnetworks.optimizer.stopping-conditions :refer [max-iterations]]))
+            [neuralnetworks.optimizer.stopping-conditions :refer [max-iterations]]
+            [neuralnetworks.utils :refer [approx]]))
 
 (deftest test-update-thetas
   (let [theta1 (m/array [[0.10000 0.30000 0.50000]
@@ -33,12 +34,40 @@
 
 (deftest test-check-for-gradients
   (let [cost-fn (fn [_] {:cost 123})
-        gradient-descent (gd/gradient-descent 1 [(max-iterations 2)])]
+        gradient-descent (gd/gradient-descent 1 1 [(max-iterations 2)])]
     (is (thrown? Exception (optimizer/optimize gradient-descent cost-fn [1])))))
 
 (deftest test-gradient-descent-optimizer
-  (let [cost-fn (fn [theta] {:cost (m/esum theta) :gradients (- (m/esum theta) 5) :theta theta})
-        gradient-descent (gd/gradient-descent 1 [(max-iterations 3)])]
-    (is (= {:iteration 3 :error nil :thetas [5]}
-           (optimizer/optimize gradient-descent cost-fn [10 10])))))
+  (let [cost-fn (fn [theta]
+                  ; cost function is [x.^2 + y.^2]
+                  ; gradient is the derivative [2x 2y]
+                  (let [cost (m/esum (m/pow theta 2))]
+                    {:cost      cost
+                     :gradients (m/mul theta 2)
+                     :error     (Math/abs (- 0 cost))
+                     :theta     theta}))
+        initial-theta [1000000 -1000000]
+        gradient-descent (gd/gradient-descent 4 0.8 [(max-iterations 15)])
+        gradient-descent-without-line-search (gd/gradient-descent 0.1 1 [(max-iterations 100)])
+        result (optimizer/optimize gradient-descent cost-fn initial-theta)
+        result-without-line-search (optimizer/optimize gradient-descent-without-line-search
+                                                       cost-fn
+                                                       initial-theta)]
 
+    (is (approx 0 (:error result) 1e-12))
+    (is (approx 0 (:error result-without-line-search) 1e-6))
+    (is (< (:error result) (:error result-without-line-search)))))
+
+(deftest test-line-search
+  (let [cost-fn (fn [theta]
+                  ; cost function is [x.^2 + y.^2]
+                  ; gradient is the derivative [2x 2y]
+                  (let [cost (m/esum (m/pow theta 2))]
+                    {:cost      cost
+                     :gradients (m/emap - (m/mul theta 2))
+                     :error     (Math/abs (- 0 cost))
+                     :theta     theta}))
+        alpha-without-line-search (gd/line-search cost-fn 0.1 1 [10 -10] [20 -20])
+        alpha-with-line-search (gd/line-search cost-fn 4 0.5 [10 -10] [20 -20])]
+    (is (approx 0.1 alpha-without-line-search))
+    (is (approx 0.5 alpha-with-line-search))))


### PR DESCRIPTION
Gradient descent now implements Backtracking Line Search to determine the value
of alpha (learning rate). You can still disable line search (why would you?) by
setting the `learning-rate-update-rate` to 1.0.

By default gradient descent uses the following settings:
- `learning-rate` 8
- `learning-rate-update-rate` 0.5

The reason for such a large `learning-rate` (alpha) is that to allow escaping
from local minima. After all, if the jump is too big, with the update-rate of
0.5, the optimizer will quickly revert the learning rate back to 1 after 3 tries

Neural networks options is also updated, `stopping-conditions` and
`learning-rate` are no longer part of neural networks options, it is now part of
the optimizer options

[Gradient Descent Revisited](https://www.cs.cmu.edu/~ggordon/10725-F12/slides/05-gd-revisited.pdf)
