### PR TITLE
Improved gradient search performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   iteration
 - Training time is now stored in the instance `:state` variable (in milliseconds)
 
+### Fixed
+- Improved line search algorithm, up to 2x speedup
+
 ## 0.2.1
 ### Changed
 - Removed codox factory function documentation for defrecord

--- a/src/neuralnetworks/optimizer/gradient_descent.clj
+++ b/src/neuralnetworks/optimizer/gradient_descent.clj
@@ -24,11 +24,11 @@
   [cost-fn init-alpha beta thetas theta-gradients]
   (if (approx beta 1.0 1e-10)
     init-alpha
-    (let [zero-matrix (m/zero-vector (m/length theta-gradients))]
+    (let [zero-matrix (m/zero-vector (m/length theta-gradients))
+          cost-theta (:cost (cost-fn thetas :skip-gradient))]
       (loop [alpha init-alpha]
         (let [theta-with-gradient (m/sub thetas (m/mul alpha theta-gradients))
               cost-theta-with-alpha (:cost (cost-fn theta-with-gradient :skip-gradient))
-              cost-theta (:cost (cost-fn thetas))
               gradient-length-squard-with-alpha (-> theta-gradients
                                                     m/length-squared
                                                     (* alpha 0.5))]


### PR DESCRIPTION
Main bottleneck was line search algorithm. Managed to double the performance by
fixing stupid bug - for every loop, it still tries to recalculate the cost of
the original thetas. Calculating cost is actually the most expensive operations.

By moving this into the outer loop, we effectively gain 2x speedup

Before and after (using vectorz)

```
| :iteration | :training-error | :cv-error | :test-error | :training-time |
|------------+-----------------+-----------+-------------+----------------|
|        100 |        0.642222 |  0.597090 |    0.508589 |           5843 |
|        200 |        0.368939 |  0.401693 |    0.249231 |          14659 |

| :iteration | :training-error | :cv-error | :test-error | :training-time |
|------------+-----------------+-----------+-------------+----------------|
|        100 |        0.642222 |  0.597090 |    0.508589 |           3008 |
|        200 |        0.368939 |  0.401693 |    0.249231 |           7329 |
```

This resolves #11
